### PR TITLE
Adding recursion to encryption

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 type KeyProvider interface {
@@ -77,27 +78,97 @@ func DecryptJsonStruct(bytes []byte, t reflect.Type, providers map[string]Crypto
 	return DecryptJsonFields(bytes, fieldProviders)
 }
 
-func EncryptJsonFields(bytes []byte, fields map[string]CryptoProvider) ([]byte, error) {
-	var doc map[string]json.RawMessage
+func EncryptVal(val interface{}, crypt CryptoProvider) (map[string]interface{}, error) {
 
-	err := json.Unmarshal(bytes, &doc)
+	byteConversion, err := json.Marshal(val)
+	byteConversion = json.RawMessage(byteConversion)
+
 	if err != nil {
 		return nil, err
 	}
 
-	for field, crypt := range fields {
-		if val, ok := doc[field]; ok {
-			encData, err := crypt.Encrypt(val)
-			if err != nil {
-				return nil, err
-			}
+	encData, err := crypt.Encrypt(byteConversion)
 
-			doc["__crypt_"+field] = encData
-			delete(doc, field)
+	if err != nil {
+		return nil, err
+	}
+
+	var temp map[string]interface{}
+	err = json.Unmarshal(encData, &temp)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return temp, nil
+}
+
+func EncryptJsonFieldsRecursive(doc map[string]interface{}, fields map[string]CryptoProvider, depth int) error {
+
+	for key, docPart := range doc {
+
+		//Loop through the fields that need encryption which are represented as a dot notation path
+		for field, crypt := range fields {
+
+			//covert the dot notation to a slice
+			path := strings.Split(field, ".")
+
+			for ind, part := range path {
+				//only check parts at the level we are at
+				if ind == depth && part == key {
+
+					v := reflect.ValueOf(docPart)
+
+					//don't encrypt a part if we are not at the end of the path
+					if (v.Kind() == reflect.Map || v.Kind() == reflect.Slice) && ind+1 < len(path) {
+						//check the next level
+						switch v.Kind() {
+						case reflect.Slice:
+							for _, slicePart := range docPart.([]interface{}) {
+								EncryptJsonFieldsRecursive(slicePart.(map[string]interface{}), fields, ind+1)
+							}
+						case reflect.Map:
+							EncryptJsonFieldsRecursive(docPart.(map[string]interface{}), fields, ind+1)
+						}
+
+					} else {
+
+						result, err := EncryptVal(docPart, crypt)
+
+						if err != nil {
+							return err
+						}
+
+						//add the encrypted value to the doc
+						doc["__crypt_"+part] = result
+
+						//remove the original non-encrypted version
+						delete(doc, part)
+					}
+				}
+			}
 		}
 	}
 
+	return nil
+}
+
+func EncryptJsonFields(data []byte, fields map[string]CryptoProvider) ([]byte, error) {
+	var doc map[string]interface{}
+
+	err := json.Unmarshal(data, &doc)
+	if err != nil {
+		return nil, err
+	}
+
+	err = EncryptJsonFieldsRecursive(doc, fields, 0)
+
+	if err != nil {
+		return nil, err
+	}
+
 	newBytes, err := json.Marshal(doc)
+
 	if err != nil {
 		return nil, err
 	}
@@ -105,24 +176,88 @@ func EncryptJsonFields(bytes []byte, fields map[string]CryptoProvider) ([]byte, 
 	return newBytes, nil
 }
 
+func DecryptVal(val interface{}, crypt CryptoProvider) (interface{}, error) {
+
+	byteConversion, _ := json.Marshal(val)
+
+	encData, err := crypt.Decrypt(byteConversion)
+
+	var temp interface{}
+	err = json.Unmarshal(encData, &temp)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return temp, nil
+
+}
+
+func DecryptJsonFieldsRecursive(doc map[string]interface{}, fields map[string]CryptoProvider, depth int) error {
+
+	for key, docPart := range doc {
+
+		//Loop through the fields that need encryption which are represented as a dot notation path
+		for field, crypt := range fields {
+
+			//covert the dot notation to a slice
+			path := strings.Split(field, ".")
+
+			for ind, part := range path {
+				//only check parts at the level we are at matching on encrypted or non-encrypted keys
+				if ind == depth && ("__crypt_"+part == key || part == key) {
+					v := reflect.ValueOf(docPart)
+
+					//don't decrypt a part if we are not at the end of the path
+					if (v.Kind() == reflect.Map || v.Kind() == reflect.Slice) && ind+1 < len(path) {
+						//check the next level
+						switch v.Kind() {
+						case reflect.Slice:
+							for _, slicePart := range docPart.([]interface{}) {
+								DecryptJsonFieldsRecursive(slicePart.(map[string]interface{}), fields, ind+1)
+							}
+						case reflect.Map:
+							DecryptJsonFieldsRecursive(docPart.(map[string]interface{}), fields, ind+1)
+						}
+
+					} else {
+
+						//Only decrypt encrypted values which we know have been encrypted because they have "__crypt_" in the path
+						if "__crypt_"+part == key {
+							result, err := DecryptVal(docPart, crypt)
+
+							if err != nil {
+								return err
+							}
+
+							//add the decrypted value to the doc
+							doc[part] = result
+
+							//remove the encrypted doc part
+							delete(doc, "__crypt_"+part)
+						}
+
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 func DecryptJsonFields(bytes []byte, fields map[string]CryptoProvider) ([]byte, error) {
-	var doc map[string]json.RawMessage
+	var doc map[string]interface{}
 
 	err := json.Unmarshal(bytes, &doc)
 	if err != nil {
 		return nil, err
 	}
 
-	for field, crypt := range fields {
-		if val, ok := doc["__crypt_"+field]; ok {
-			encData, err := crypt.Decrypt(val)
-			if err != nil {
-				return nil, err
-			}
+	err = DecryptJsonFieldsRecursive(doc, fields, 0)
 
-			doc[field] = encData
-			delete(doc, "__crypt_"+field)
-		}
+	if err != nil {
+		return nil, err
 	}
 
 	newBytes, err := json.Marshal(doc)

--- a/rsaprovider.go
+++ b/rsaprovider.go
@@ -44,9 +44,12 @@ func (cp *RsaCryptoProvider) Encrypt(data []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	pubKey, err := parsePKCS1PublicKey(pubKeyBytes)
+	pubKey, err := parsePKCS1PublicKeyPem(pubKeyBytes)
 	if err != nil {
-		return nil, err
+		pubKey, err = parsePKCS1PublicKey(pubKeyBytes)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	ciphertext, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, pubKey, data, nil)
@@ -102,9 +105,12 @@ func (cp *RsaCryptoProvider) Decrypt(data []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	privKey, err := parsePKCS1PrivateKey(privKeyBytes)
+	privKey, err := parsePKCS1PrivateKeyPem(privKeyBytes)
 	if err != nil {
-		return nil, err
+		privKey, err = parsePKCS1PrivateKey(privKeyBytes)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if encBlock.Algorithm != "RSA-2048-OEP" {


### PR DESCRIPTION
Encryption could only be done at the top level thus limiting the scope of field level encryption.  Recursion was added in order to improve the granularity of field level encryption.  PEM key support was also added for RSA providers.